### PR TITLE
fix: not perfect but trying to account for narrow and wide windows

### DIFF
--- a/src/genesis/ui/multipleTask.ts
+++ b/src/genesis/ui/multipleTask.ts
@@ -110,7 +110,7 @@ export class MultipleTasks extends Widget {
     this.auxcontainer.name = 'questBoxContainer'
     this.auxcontainer.width = 280
     this.auxcontainer.height = 150
-    this.auxcontainer.positionX = "-11%"
+    this.auxcontainer.positionX = "-30%"//-80//"-11%"// percent was causing text off screen on narrow windows
     this.auxcontainer.positionY = "50%"
     this.auxcontainer.vAlign = 'center'
     this.auxcontainer.hAlign = 'center'
@@ -123,7 +123,8 @@ export class MultipleTasks extends Widget {
     title.color = new Color4(1, 1, 1)
     title.vAlign = 'top'
     title.hAlign = 'left'
-    title.positionX = "7%"
+    //title.positionX = "7%" //padding is what is wanted
+    title.paddingLeft = 10
     title.positionY = -15
     title.hTextAlign = "left"
     title.vTextAlign = "top"

--- a/src/imports/widgets/widgetTasks.ts
+++ b/src/imports/widgets/widgetTasks.ts
@@ -111,7 +111,7 @@ export class WidgetTasksBox extends Widget {
     this.auxcontainer.name = 'questBoxContainer'
     this.auxcontainer.width = 280
     this.auxcontainer.height = 80
-    this.auxcontainer.positionX = "-11%"
+    this.auxcontainer.positionX = "-30%"//-80//"-11%"// percent was causing text off screen on narrow windows
     this.auxcontainer.positionY = "50%"
     this.auxcontainer.vAlign = 'center'
     this.auxcontainer.hAlign = 'center'
@@ -189,10 +189,11 @@ export class WidgetTasks extends WidgetTasksBox {
       this.textUI[i].color = Color4.White()
       this.textUI[i].vAlign = 'top'
       this.textUI[i].hAlign = 'left'
-      this.textUI[i].positionX = "7%"
+      //this.textUI[i].positionX = "7%" //padding is what is wanted
+      this.textUI[i].paddingLeft = 10
       this.textUI[i].positionY = -15
       this.textUI[i].hTextAlign = "left"
-      this.textUI[i].vTextAlign = "top"
+      this.textUI[i].vTextAlign = "top" 
 
       if (this.taskType == TaskType.Simple) {
         this.infoUI[i] = new UIText(this.auxcontainer)


### PR DESCRIPTION
not perfect by time consuming,  good balance here for now of shows more of the widget

after-narrow
![after-narrow](https://user-images.githubusercontent.com/2999141/223805436-0b4e0dda-09ff-41af-872f-253b3ff4751b.png)
before-narrow
![before-narrow](https://user-images.githubusercontent.com/2999141/223805443-a01c2fbf-de80-4b0d-87de-c7a75e05d9f9.png)
before-wide
![before-wide](https://user-images.githubusercontent.com/2999141/223805447-644a918d-b120-43b9-8950-02972a604ad5.png)
after-wide
![after-wide](https://user-images.githubusercontent.com/2999141/223805451-2ca30d38-f881-421f-ba93-d25cf1b40a68.png)
