### PR TITLE
Fix: Clean captcha condition

### DIFF
--- a/src/claiming-dropin/claiming/loot.ts
+++ b/src/claiming-dropin/claiming/loot.ts
@@ -768,7 +768,7 @@ export class ClaimUI {
 
       serverURL = ensureFormat(serverURL)
 
-      if((hasCaptchaData && captchaData.image.indexOf("data")==0 )|| serverURL.indexOf("local")==0){
+      if(hasCaptchaData || serverURL.indexOf("local")==0){
         serverURL = captchaData.image
       }
       const imgScale = 1.4


### PR DESCRIPTION
Removed string.indexOf query when setting the image captcha so it gets displayed correctly in renderer. Probably this got broke by changing the rewards server. 

I cant confirm it because the original contributor is no longer with us. Anyways, this simple fix solves the issue